### PR TITLE
Use JSDOM environment for testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "webpack-cli": "^4.7.2"
   },
   "jest": {
+    "testEnvironment": "jsdom",
     "moduleNameMapper": {
       "\\.s?css$": "<rootDir>/mocks/styleMock.js"
     },


### PR DESCRIPTION
Jest will default to a node environment for tests in the next major version. Since most (all?) of the tests are for the browser, the environment should be switched to `jsdom`.